### PR TITLE
Fix referencing of env variable

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,7 +45,7 @@ jobs:
     needs: verify-release
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ needs.release-version.outputs.release_version }}
+      RELEASE_VERSION: ${{ needs.verify-release.outputs.release_version }}
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}
     steps:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The referencing env and outputs in github action follows the format:

```
    outputs:
      <outputName>: ${{ steps.<stepID>.outputs.<variableKey> }}
    steps:
      - id: <stepID>
        run: echo "<variableKey>=<variableValue>" >> "$GITHUB_OUTPUT"

   env:
     <OUTPUTNAME>: ${{needs.<jobName>.outputs.<outputName>}}
```

See also: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

Changes proposed in this pull request:

- Use `jobName` in env section instead of `stepID`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
