### PR TITLE
Add case to handle no previous release tag in create changelog

### DIFF
--- a/scripts/create_changelog.sh
+++ b/scripts/create_changelog.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
+# Optional args need to be handled before 'set -o nonset'.
 PREVIOUS_RELEASE=$2 # for testability
 
-# standard bash error handling
+# Error handling.
 set -o nounset  # treat unset variables as an error and exit immediately.
 set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
@@ -10,47 +11,64 @@ set -o pipefail # prevents errors in a pipeline from being masked
 
 RELEASE_TAG=$1
 
-REPOSITORY=${REPOSITORY:-kyma-project/eventing-publisher-proxy}
+REPOSITORY=${REPOSITORY:-kyma-project/nats-manager}
 GITHUB_URL=https://api.github.com/repos/${REPOSITORY}
 GITHUB_AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 CHANGELOG_FILE="CHANGELOG.md"
 
-if [ "${PREVIOUS_RELEASE}"  == "" ]
-then
-  PREVIOUS_RELEASE=$(git describe --tags --abbrev=0)
+# If the previous release was not passed, we will
+if [ "${PREVIOUS_RELEASE}" == "" ]; then
+	# The git describe --tag --abbrev=0 command is used to find the most recent tag that is reachable from a commit.
+	# The --tag option tells git describe to consider any tag found in the refs/tags namespace, enabling matching a lightweight (non-annotated) tag.
+	# Redirect stderr to stdout
+	PREVIOUS_RELEASE=$(git describe --tags --abbrev=0 2>$1)
+	exit_code=$?
+
+  if [ $exit_code -eq 0 ]; then
+      # Successful command
+      echo "Latest tag: $PREVIOUS_RELEASE"
+  else
+      # Error handling
+      echo "Error: $PREVIOUS_RELEASE"
+      PREVIOUS_RELEASE="238cdae"
+      echo "No previous release found. Using first commit sha: ${PREVIOUS_RELEASE} from EPP repository move."
+  fi
 fi
 
-echo "## What has changed" >> ${CHANGELOG_FILE}
+# Generate the changelog in the CHANGELOG.md.
+echo "## What has changed" >>${CHANGELOG_FILE}
 
-git log ${PREVIOUS_RELEASE}..HEAD --pretty=tformat:"%h" --reverse | while read -r commit
-do
-    COMMIT_AUTHOR=$(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/commits/${commit}" | jq -r '.author.login')
-    if [ "${COMMIT_AUTHOR}" != "kyma-bot" ]; then
-      git show -s ${commit} --format="* %s by @${COMMIT_AUTHOR}" >> ${CHANGELOG_FILE}
-    fi
+# Iterate over all commits since the previous release.
+git log ${PREVIOUS_RELEASE}..HEAD --pretty=tformat:"%h" --reverse | while read -r commit; do
+	# If the author of the commit is not kyma-bot, show append the commit message to the changelog.
+	COMMIT_AUTHOR=$(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/commits/${commit}" | jq -r '.author.login')
+	if [ "${COMMIT_AUTHOR}" != "kyma-bot" ]; then
+		git show -s ${commit} --format="* %s by @${COMMIT_AUTHOR}" >>${CHANGELOG_FILE}
+	fi
 done
 
+# Create a new file (with a unique name based on the process ID of the current shell).
 NEW_CONTRIB=$$.new
 
+# Find unique authors that contribute since the last release, but not before it, and to the NEW_CONTRIB file.
 join -v2 \
-<(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/compare/$(git rev-list --max-parents=0 HEAD)...${PREVIOUS_RELEASE}" | jq -r '.commits[].author.login' | sort -u) \
-<(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/compare/${PREVIOUS_RELEASE}...HEAD" | jq -r '.commits[].author.login' | sort -u) >${NEW_CONTRIB}
+	<(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/compare/$(git rev-list --max-parents=0 HEAD)...${PREVIOUS_RELEASE}" | jq -r '.commits[].author.login' | sort -u) \
+	<(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/compare/${PREVIOUS_RELEASE}...HEAD" | jq -r '.commits[].author.login' | sort -u) >${NEW_CONTRIB}
 
-if [ -s ${NEW_CONTRIB} ]
-then
-  echo -e "\n## New contributors" >> ${CHANGELOG_FILE}
-  while read -r user
-  do
-    REF_PR=$(grep "@${user}" ${CHANGELOG_FILE} | head -1 | grep -o " (#[0-9]\+)" || true)
-    if [ -n "${REF_PR}" ] #reference found
-    then
-      REF_PR=" in ${REF_PR}"
-    fi
-    echo "* @${user} made first contribution${REF_PR}" >> ${CHANGELOG_FILE}
-  done <${NEW_CONTRIB}
+# Add new contributors to the 'new contributors' section of the changelog.
+if [ -s ${NEW_CONTRIB} ]; then
+	echo -e "\n## New contributors" >>${CHANGELOG_FILE}
+	while read -r user; do
+		REF_PR=$(grep "@${user}" ${CHANGELOG_FILE} | head -1 | grep -o " (#[0-9]\+)" || true)
+		if [ -n "${REF_PR}" ]; then #reference found
+			REF_PR=" in ${REF_PR}"
+		fi
+		echo "* @${user} made first contribution${REF_PR}" >>${CHANGELOG_FILE}
+	done <${NEW_CONTRIB}
 fi
 
-echo -e "\n**Full changelog**: https://github.com/$REPOSITORY/compare/${PREVIOUS_RELEASE}...${RELEASE_TAG}" >> ${CHANGELOG_FILE}
+# Append link to the full-changelog this changelog.
+echo -e "\n**Full changelog**: https://github.com/$REPOSITORY/compare/${PREVIOUS_RELEASE}...${RELEASE_TAG}" >>${CHANGELOG_FILE}
 
-# cleanup
+# Cleanup the NEW_CONTRIB file.
 rm ${NEW_CONTRIB} || echo "cleaned up"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The changelog is created using a previous release tag as reference point. In case no tag exists, the script failed.

Changes proposed in this pull request:

- Script uses hard coded sha to use as reference point in case no previous release tag exists to create the changelog
- Add comments from NM repo to the script for explanation of the steps

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
