### PR TITLE
Make readiness state of EPP dependant on availability of NATS

### DIFF
--- a/pkg/sender/jetstream/health.go
+++ b/pkg/sender/jetstream/health.go
@@ -1,6 +1,7 @@
 package jetstream
 
 import (
+	"github.com/nats-io/nats.go"
 	"net/http"
 
 	"github.com/kyma-project/eventing-publisher-proxy/pkg/handler/health"
@@ -10,6 +11,11 @@ import (
 // It checks the NATS server connection status and reports 2XX if connected, otherwise reports 5XX.
 // It panics if the given NATS Handler is nil.
 func (s *Sender) ReadinessCheck(w http.ResponseWriter, _ *http.Request) {
+	if status := s.ConnectionStatus(); status != nats.CONNECTED {
+		s.namedLogger().Error("Readiness check failed: not connected to nats server")
+		w.WriteHeader(health.StatusCodeNotHealthy)
+		return
+	}
 	w.WriteHeader(health.StatusCodeHealthy)
 }
 

--- a/pkg/sender/jetstream/health.go
+++ b/pkg/sender/jetstream/health.go
@@ -1,8 +1,9 @@
 package jetstream
 
 import (
-	"github.com/nats-io/nats.go"
 	"net/http"
+
+	"github.com/nats-io/nats.go"
 
 	"github.com/kyma-project/eventing-publisher-proxy/pkg/handler/health"
 )


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
In the past, it was necessary to decouple the readiness of EPP from NATS as done here: [kyma/#18307](https://github.com/kyma-project/kyma/pull/18307). This was due to the move to modular Kyma, where the EPP was always present in the cluster. However, if no NATS module was installed, the EPP was in CrashLoopBackOff.

This needs to be undone, as now Eventing is completely modular to ensure no event loss during rollout of new EPP pods.

Changes proposed in this pull request:

- Base readiness of EPP on availability of NATS

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#46 