### PR TITLE
fix: schedule of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "weekly"
       day: monday
-      time: 07:00
+      time: "07:00"
     commit-message:
       prefix: "deps(dependabot)"
   - package-ecosystem: "docker" # See documentation for possible values
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "weekly"
       day: monday
-      time: 07:00
+      time: "07:00"
     commit-message:
       prefix: "deps(dependabot)"
   - package-ecosystem: "github-actions" # See documentation for possible values
@@ -25,6 +25,6 @@ updates:
     schedule:
       interval: "weekly"
       day: monday
-      time: 07:00
+      time: "07:00"
     commit-message:
       prefix: "deps(dependabot)"


### PR DESCRIPTION
The [`schedule.time`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime) needs to be quoted or it will be interpreted as a string.

**Description**

Changes proposed in this pull request:

- Put `schedule.time` in quotes.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
