### PR TITLE
chore: upgrade golangci-lint version to v1.60.3

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -31,4 +31,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           args: --timeout=10m
-          version: v1.57
+          version: v1.60.3

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -28,6 +28,8 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
+        env:
+          GOGC: "90" # Garbage collection limit to avoid OOM errors
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           args: --timeout=10m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

I was facing the following issue with version 1.57 and Go 1.23:
```
Killed
Error: golangci-lint exit with code 137
```

Changes proposed in this pull request:

- golangci-lint version 1.57 has a bug with Go 1.23 (https://github.com/golangci/golangci-lint-action/issues/1094)

**Related issue(s)**


<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
